### PR TITLE
docs: fix repository clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It allows you to **upload PDF or CSV documents, store them as vector embeddings 
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/your-username/ragify.git
+git clone https://github.com/your-username/rag-service.git
 cd rag-service
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It allows you to **upload PDF or CSV documents, store them as vector embeddings 
 
 1. Clone the repository:
 ```bash
-git clone https://github.com/your-username/rag-service.git
+git clone https://github.com/HagaiHen/rag-service.git
 cd rag-service
 ```
 


### PR DESCRIPTION
## Summary
- fix the README's repository clone URL

## Testing
- `grep -n rag-service.git README.md`

------
https://chatgpt.com/codex/tasks/task_e_6841c5a6bb3c832480e73c32be1b831a