### PR TITLE
Improve chat history with summarization

### DIFF
--- a/app/services/openai_llm.py
+++ b/app/services/openai_llm.py
@@ -15,3 +15,18 @@ def get_openai_completion(prompt: str, model: str = "gpt-3.5-turbo") -> str:
         ]
     )
     return response.choices[0].message.content.strip()
+
+
+def summarize_text(text: str, model: str = "gpt-3.5-turbo") -> str:
+    """Return a short summary for the provided text using the OpenAI API."""
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "system",
+                "content": "Summarize the following conversation in a concise manner.",
+            },
+            {"role": "user", "content": text},
+        ],
+    )
+    return response.choices[0].message.content.strip()


### PR DESCRIPTION
## Summary
- add text summarization helper using OpenAI
- support running summaries of chat sessions
- truncate cached history when it grows too large

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ae271c5f48324a7c55822fbac7f86