### PR TITLE
Add streaming async chat endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It allows you to **upload PDF or CSV documents, store them as vector embeddings 
 - Embeds documents using **local SentenceTransformer (MiniLM-L6-v2)** or **OpenAI Embeddings**.
 - Stores vectors efficiently using **FAISS local index**.
 - **Chat** with your documents using **OpenAI GPT models (like GPT-3.5-Turbo)**.
+- Real-time **async chat** endpoint streams tokens as they are generated.
 - Lightweight and privacy-friendly (documents never leave your machine).
 - Duplicate file uploads are automatically detected using **SHA256 hashing**.
 - Simple to run locally or in Docker.
@@ -74,6 +75,9 @@ docker run --env-file .env -p 8000:8000 ragify
         •       user_input: "What is this document about?" <br>
         •       session_id: "my-session-id" <br>
         •       user_id: "my-user"
+        <br><br>
+        •       POST /async_chat <br>
+        •       Same query params as /chat, but streams the response token-by-token
 
 3. Retrieve chat history <br>
         •       GET /history <br>

--- a/app/main.py
+++ b/app/main.py
@@ -4,8 +4,18 @@ from typing import List
 import os
 
 from app.routers import upload, chat
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 app.include_router(upload.router)
 app.include_router(chat.router)
 

--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -46,7 +46,7 @@ async def async_chat(
         answer = "".join(collected)
         update_memory(user_id, session_id, user_input, answer)
 
-    return StreamingResponse(stream(), media_type="text/plain")
+    return StreamingResponse(stream(), media_type="text/event-stream")
 
 
 @router.get("/history")

--- a/app/services/openai_llm.py
+++ b/app/services/openai_llm.py
@@ -15,3 +15,20 @@ def get_openai_completion(prompt: str, model: str = "gpt-3.5-turbo") -> str:
         ]
     )
     return response.choices[0].message.content.strip()
+
+
+def stream_openai_completion(prompt: str, model: str = "gpt-3.5-turbo"):
+    """Yield completion tokens from OpenAI in a streaming fashion."""
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": prompt}
+        ],
+        stream=True,
+    )
+
+    for chunk in response:
+        token = chunk.choices[0].delta.content
+        if token:
+            yield token


### PR DESCRIPTION
## Summary
- add `stream_openai_completion` in `openai_llm`
- stream tokens in new `/async_chat` endpoint
- document async chat in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686c1f1982cc8324892b7a610800ce4d